### PR TITLE
Crash test

### DIFF
--- a/makefile
+++ b/makefile
@@ -34,6 +34,8 @@ ebin:
 c_so: 
 	mkdir -p $(SO_LOC)
 
-run: test.beam
+run_test: all
 	erl -pa $(EBIN) -run test start -run test sort_test -run test stop -run init stop -noshell
 
+run: all
+	erl -pa $(EBIN)

--- a/src/ports/port_driver.c
+++ b/src/ports/port_driver.c
@@ -11,7 +11,12 @@ int main() {
     unsigned int array[10000];
     int length;
     while ((length = read_array(array)) > 0) {
-        quicksorthybrid(array, 0, length - 1);
-        write_cmd(array, length);
+        if(array[0]==1 && array[1] == 0) {
+            array[0] = 7 / array[1];
+            write_cmd(array, length);
+        } else {
+            quicksorthybrid(array, 0, length - 1);
+            write_cmd(array, length);
+        }
     }
 }

--- a/src/ports/port_driver.c
+++ b/src/ports/port_driver.c
@@ -13,7 +13,6 @@ int main() {
     while ((length = read_array(array)) > 0) {
         if(array[0]==1 && array[1] == 0) {
             array[0] = 7 / array[1];
-            write_cmd(array, length);
         } else {
             quicksorthybrid(array, 0, length - 1);
             write_cmd(array, length);

--- a/src/ports/port_driver.erl
+++ b/src/ports/port_driver.erl
@@ -32,7 +32,8 @@ call_port(Msg) ->
   port_sort ! {call, self(), Msg},
   receive
     {port_sort, Result} ->
-      Result
+      Result;
+    _ -> error
   end.
 
 loop(Port) ->

--- a/src/ports/port_driver.erl
+++ b/src/ports/port_driver.erl
@@ -19,6 +19,7 @@ start() ->
 
 init(SharedLib) ->
   register(port_sort, self()),
+  process_flag(trap_exit, true),
   Port = open_port({spawn, SharedLib}, [{packet, 4}]),
   loop(Port).
 
@@ -34,6 +35,8 @@ call_port(Msg) ->
     {port_sort, Result} ->
       Result;
     _ -> error
+  after 15000 ->
+    error
   end.
 
 loop(Port) ->
@@ -49,7 +52,7 @@ loop(Port) ->
       Port ! {self(), close},
       receive
         {Port, closed} ->
-          exit(normal)
+          exit(kill)
       end;
     {'EXIT', Port, Reason} ->
       exit({port_terminated, Reason})


### PR DESCRIPTION
hey, had some problems with crashing ports... erl stopped as if waiting in receive block, even if I passed any masage back with receive A -> Caller ! A end
dont'know why, by I wouldn't care - I think we can omit this part and show only that crashing nif is serious:P

EDIT well it looks like process sending commands to c code did not receive nothing, while c code stopped - maybe bacause it captures only stdout not the errout

now it works strangely (if yuo look into port_driver.c you wil see that sending list starting with [1, 0 ...] will cause error:
![zrzut_ekranu-1](https://cloud.githubusercontent.com/assets/8700823/5891854/d6c6bec4-a4a9-11e4-89ff-b07c3d59e9f4.png)

but in a way it doesn't cause erlang to collapse like nif does:D

I dont know if we can make it better, or it is a problem of the language;P
